### PR TITLE
Add header layout config

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,35 @@
-import React from 'react';
+import layoutConfig from '../config/section-globals.json';
+
+const headerLayout = (layoutConfig as any).Header.layout;
 
 export default function Header() {
   return (
-    <section>
-      {/* TODO: conteúdo da seção Header */}
-    </section>
+    <header className={`grid ${headerLayout.gridClasses.mobile} ${headerLayout.gridClasses.md}`}>
+      {/* Coluna 1 – Logo */}
+      <div>
+        <img src="/logo.png" alt="Logo" />
+      </div>
+
+      {/* Coluna 2 – Conteúdo dinâmico */}
+      <div className={headerLayout.col2.classes}>
+        {headerLayout.col2.contentOrder.map((item) => {
+          if (headerLayout.col2.hideOn.mobile.includes(item)) return null;
+          switch (item) {
+            case 'nav':
+              return <nav key="nav">/* links */</nav>;
+            case 'phone':
+              return <span key="phone">(11) 99999-0000</span>;
+            case 'hamburgerIcon':
+              return (
+                <button key="hamburger" className="md:hidden">
+                  ☰
+                </button>
+              );
+            default:
+              return null;
+          }
+        })}
+      </div>
+    </header>
   );
 }

--- a/config/section-globals.json
+++ b/config/section-globals.json
@@ -1,0 +1,13 @@
+{
+  "Header": {
+    "layout": {
+      "columns": { "mobile": 1, "md": 2 },
+      "gridClasses": { "mobile": "grid-cols-1", "md": "md:grid-cols-2" },
+      "col2": {
+        "classes": "flex items-center justify-center md:justify-end mb-8",
+        "contentOrder": ["nav", "phone", "hamburgerIcon"],
+        "hideOn": { "mobile": ["nav", "phone"], "md": [] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add layout configuration for Header
- implement Header using new config

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ba0f3c483299d9ac9ba6afcc6e0